### PR TITLE
Use Node.js-native watch

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,7 +1,0 @@
-{
-  "watch": [
-    "built",
-    "public"
-  ],
-  "ext": "css js"
-}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "unit-test": "mocha --config test/.mocharc.json",
     "build": "webpack",
     "watch": "webpack --watch",
-    "start": "npm run watch & nodemon --require source-map-support/register built/main.js"
+    "start": "npm run watch & node --watch-path=built --watch-path=public --require source-map-support/register built/main.js"
   },
   "pre-commit": [
     "lint-check",
@@ -59,7 +59,6 @@
     "lintspaces-cli": "0.7.1",
     "mini-css-extract-plugin": "2.6.1",
     "mocha": "10.0.0",
-    "nodemon": "2.0.20",
     "pre-commit": "1.2.2",
     "process": "0.11.10",
     "sass": "1.55.0",


### PR DESCRIPTION
This PR removes its dependency on Nodemon in favour of the Node.js-native `--watch` option

### References:
- [Node.js v22.2.0 | Command-line API: `--watch-path`](https://nodejs.org/docs/v22.2.0/api/cli.html#--watch-path)