### PR TITLE
Add fetchData property to Not Found route

### DIFF
--- a/src/react/routes.js
+++ b/src/react/routes.js
@@ -239,6 +239,7 @@ export default [
 	{
 		path: '*',
 		documentTitle: () => 'Not Found',
-		component: NotFound
+		component: NotFound,
+		fetchData: []
 	}
 ];


### PR DESCRIPTION
This PR fixes a bug which can be observed when visiting the Not Found route (e.g. http://localhost:3002/foo) as the first visit to the app.

```
Warning: Failed prop type: The prop `fetchData` is marked as required in `Layout`, but its value is `undefined`.
```

![Screenshot 2024-08-23 at 14 47 21](https://github.com/user-attachments/assets/fe916211-15bd-4093-a4a5-931718d0b0a3)