### PR TITLE
Use JSX automatic import transform

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,6 +39,7 @@
     "no-var": 2,
     "one-var": [2, "never"],
     "quotes": [2, "single"],
+    "react/react-in-jsx-scope": 0,
     "semi": 2,
     "space-before-function-paren": 2,
     "spaced-comment": 2,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,6 +20,7 @@ const serverBundle = {
 		'node:http',
 		'prop-types',
 		'react',
+		'react/jsx-runtime',
 		'react-bootstrap-typeahead',
 		'react-dom/server',
 		'react-helmet',
@@ -34,6 +35,7 @@ const serverBundle = {
 	},
 	plugins: [
 		esbuild({
+			jsx: 'automatic',
 			jsxFactory: 'React.createElement',
 			jsxFragment: 'React.Fragment'
 		}),
@@ -61,7 +63,12 @@ const clientScriptsBundle = {
 		}),
 		babel({
 			babelHelpers: 'bundled',
-			presets: ['@babel/preset-react'],
+			presets: [
+				[
+					'@babel/preset-react',
+					{ runtime: 'automatic' }
+				]
+			],
 			extensions: ['.js', '.jsx']
 		}),
 		commonjs(),

--- a/src/react/AppRoutes.jsx
+++ b/src/react/AppRoutes.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route, Routes, useLocation } from 'react-router-dom';
 
 import Layout from './Layout.jsx';

--- a/src/react/Layout.jsx
+++ b/src/react/Layout.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
 import { useMatch } from 'react-router-dom';

--- a/src/react/client-mount.jsx
+++ b/src/react/client-mount.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';

--- a/src/react/components/AppendedCoEntities.jsx
+++ b/src/react/components/AppendedCoEntities.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { Entities } from './index.js';
 

--- a/src/react/components/AppendedDate.jsx
+++ b/src/react/components/AppendedDate.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { formatDate } from '../../lib/format-date.js';
 

--- a/src/react/components/AppendedDepictions.jsx
+++ b/src/react/components/AppendedDepictions.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Fragment } from 'react';
 
 const AppendedDepictions = props => {
 
@@ -11,7 +11,7 @@ const AppendedDepictions = props => {
 			{
 				depictions
 					.map((depiction, index) =>
-						<React.Fragment key={index}>
+						<Fragment key={index}>
 
 							{
 								depiction.displayName && (
@@ -33,7 +33,7 @@ const AppendedDepictions = props => {
 								)
 							}
 
-						</React.Fragment>
+						</Fragment>
 					)
 					.reduce((accumulator, currentValue) => [accumulator, ' /', currentValue])
 			}

--- a/src/react/components/AppendedEmployerCompany.jsx
+++ b/src/react/components/AppendedEmployerCompany.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { CommaSeparatedInstanceLinks, InstanceLink } from './index.js';
 

--- a/src/react/components/AppendedEntities.jsx
+++ b/src/react/components/AppendedEntities.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { Entities } from './index.js';
 

--- a/src/react/components/AppendedFormatAndYear.jsx
+++ b/src/react/components/AppendedFormatAndYear.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 const AppendedFormatAndYear = props => {
 

--- a/src/react/components/AppendedMembers.jsx
+++ b/src/react/components/AppendedMembers.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { CommaSeparatedInstanceLinks } from './index.js';
 

--- a/src/react/components/AppendedPerformers.jsx
+++ b/src/react/components/AppendedPerformers.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Fragment } from 'react';
 
 import { InstanceLink, JoinedRoles } from './index.js';
 
@@ -15,7 +15,7 @@ const AppendedPerformers = props => {
 			{
 				performers
 					.map((performer, index) =>
-						<React.Fragment key={index}>
+						<Fragment key={index}>
 
 							<InstanceLink instance={performer} />
 
@@ -53,7 +53,7 @@ const AppendedPerformers = props => {
 								)
 							}
 
-						</React.Fragment>
+						</Fragment>
 					)
 					.reduce((accumulator, currentValue) => [accumulator, ' / ', currentValue])
 			}

--- a/src/react/components/AppendedProductionDates.jsx
+++ b/src/react/components/AppendedProductionDates.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { formatDate } from '../../lib/format-date.js';
 

--- a/src/react/components/AppendedProductionTeamCredits.jsx
+++ b/src/react/components/AppendedProductionTeamCredits.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Fragment } from 'react';
 
 import { AppendedCoEntities, AppendedEmployerCompany, AppendedMembers } from './index.js';
 
@@ -15,7 +15,7 @@ const AppendedProductionTeamCredits = props => {
 			{
 				credits
 					.map((credit, index) =>
-						<React.Fragment key={index}>
+						<Fragment key={index}>
 
 							<>{ credit.name }</>
 
@@ -37,7 +37,7 @@ const AppendedProductionTeamCredits = props => {
 								)
 							}
 
-						</React.Fragment>
+						</Fragment>
 					)
 					.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
 			}

--- a/src/react/components/AppendedQualifier.jsx
+++ b/src/react/components/AppendedQualifier.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 const AppendedQualifier = props => {
 

--- a/src/react/components/AppendedRoles.jsx
+++ b/src/react/components/AppendedRoles.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { JoinedRoles } from './index.js';
 

--- a/src/react/components/AppendedVenue.jsx
+++ b/src/react/components/AppendedVenue.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { VenueLinkWithContext } from './index.js';
 

--- a/src/react/components/CharactersList.jsx
+++ b/src/react/components/CharactersList.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { AppendedQualifier, InstanceLink, ListWrapper } from './index.js';
 

--- a/src/react/components/CommaSeparatedInstanceLinks.jsx
+++ b/src/react/components/CommaSeparatedInstanceLinks.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Fragment } from 'react';
 
 import { InstanceLink } from './index.js';
 
@@ -13,11 +13,11 @@ const CommaSeparatedInstanceLinks = props => {
 			{
 				instances
 					.map((instance, index) =>
-						<React.Fragment key={index}>
+						<Fragment key={index}>
 
 							<InstanceLink key={index} instance={instance} />
 
-						</React.Fragment>
+						</Fragment>
 					)
 					.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
 			}

--- a/src/react/components/CommaSeparatedMaterials.jsx
+++ b/src/react/components/CommaSeparatedMaterials.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Fragment } from 'react';
 
 import { MaterialLinkWithContext } from './index.js';
 
@@ -13,11 +13,11 @@ const CommaSeparatedMaterials = props => {
 			{
 				materials
 					.map((material, index) =>
-						<React.Fragment key={index}>
+						<Fragment key={index}>
 
 							<MaterialLinkWithContext material={material} />
 
-						</React.Fragment>
+						</Fragment>
 					)
 					.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
 			}

--- a/src/react/components/CommaSeparatedProductions.jsx
+++ b/src/react/components/CommaSeparatedProductions.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Fragment } from 'react';
 
 import { ProductionLinkWithContext } from './index.js';
 
@@ -13,11 +13,11 @@ const CommaSeparatedProductions = props => {
 			{
 				productions
 					.map((production, index) =>
-						<React.Fragment key={index}>
+						<Fragment key={index}>
 
 							<ProductionLinkWithContext production={production} />
 
-						</React.Fragment>
+						</Fragment>
 					)
 					.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
 			}

--- a/src/react/components/CreativeProductionsList.jsx
+++ b/src/react/components/CreativeProductionsList.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { AppendedProductionTeamCredits, ProductionLinkWithContext, ListWrapper } from './index.js';
 

--- a/src/react/components/CrewProductionsList.jsx
+++ b/src/react/components/CrewProductionsList.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { AppendedProductionTeamCredits, ProductionLinkWithContext, ListWrapper } from './index.js';
 

--- a/src/react/components/Entities.jsx
+++ b/src/react/components/Entities.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Fragment } from 'react';
 
 import { AppendedMembers, InstanceLink } from './index.js';
 
@@ -13,7 +13,7 @@ const Entities = props => {
 			{
 				entities
 					.map((entity, index) =>
-						<React.Fragment key={index}>
+						<Fragment key={index}>
 
 							<InstanceLink instance={entity} />
 
@@ -23,7 +23,7 @@ const Entities = props => {
 								)
 							}
 
-						</React.Fragment>
+						</Fragment>
 					)
 					.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
 			}

--- a/src/react/components/ErrorMessage.jsx
+++ b/src/react/components/ErrorMessage.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { Helmet } from 'react-helmet';
 
 import { PageTitle } from './index.js';

--- a/src/react/components/FestivalLinkWithContext.jsx
+++ b/src/react/components/FestivalLinkWithContext.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { InstanceLink, PrependedSurInstance } from './index.js';
 

--- a/src/react/components/Footer.jsx
+++ b/src/react/components/Footer.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const Footer = () => {
 
 	return (

--- a/src/react/components/Header.jsx
+++ b/src/react/components/Header.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom';
 
 import { SearchBar } from './index.js';

--- a/src/react/components/InstanceDocumentTitle.jsx
+++ b/src/react/components/InstanceDocumentTitle.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { Helmet } from 'react-helmet';
 
 import { MODEL_TO_DISPLAY_NAME_MAP } from '../../utils/constants.js';

--- a/src/react/components/InstanceFacet.jsx
+++ b/src/react/components/InstanceFacet.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 const InstanceFacet = props => {
 

--- a/src/react/components/InstanceLabel.jsx
+++ b/src/react/components/InstanceLabel.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { MODEL_TO_DISPLAY_NAME_MAP } from '../../utils/constants.js';
 

--- a/src/react/components/InstanceLink.jsx
+++ b/src/react/components/InstanceLink.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { NavLink } from 'react-router-dom';
 
 import { MODEL_TO_ROUTE_MAP } from '../../utils/constants.js';

--- a/src/react/components/InstanceLinksList.jsx
+++ b/src/react/components/InstanceLinksList.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { InstanceLink, ListWrapper } from './index.js';
 

--- a/src/react/components/JoinedRoles.jsx
+++ b/src/react/components/JoinedRoles.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Fragment } from 'react';
 
 import { AppendedQualifier, InstanceLink } from './index.js';
 
@@ -13,7 +13,7 @@ const JoinedRoles = props => {
 			{
 				instances
 					.map((instance, index) =>
-						<React.Fragment key={index}>
+						<Fragment key={index}>
 
 							<span className="fictional-name-text">
 
@@ -37,7 +37,7 @@ const JoinedRoles = props => {
 								)
 							}
 
-						</React.Fragment>
+						</Fragment>
 					)
 					.reduce((accumulator, currentValue) => [accumulator, ' / ', currentValue])
 			}

--- a/src/react/components/ListWrapper.jsx
+++ b/src/react/components/ListWrapper.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 const ListWrapper = props => {
 

--- a/src/react/components/MaterialLinkWithContext.jsx
+++ b/src/react/components/MaterialLinkWithContext.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { AppendedFormatAndYear, InstanceLink, PrependedSurInstance, WritingCredits } from './index.js';
 

--- a/src/react/components/MaterialsList.jsx
+++ b/src/react/components/MaterialsList.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { ListWrapper, MaterialLinkWithContext } from './index.js';
 

--- a/src/react/components/Navigation.jsx
+++ b/src/react/components/Navigation.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom';
 
 const Navigation = () => {

--- a/src/react/components/PageSubtitle.jsx
+++ b/src/react/components/PageSubtitle.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 const PageSubtitle = props => {
 

--- a/src/react/components/PageTitle.jsx
+++ b/src/react/components/PageTitle.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 const PageTitle = props => {
 

--- a/src/react/components/PrependedSurInstance.jsx
+++ b/src/react/components/PrependedSurInstance.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { InstanceLink } from './index.js';
 

--- a/src/react/components/ProducerCredits.jsx
+++ b/src/react/components/ProducerCredits.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Fragment } from 'react';
 
 import { ProducerEntities } from './index.js';
 import { capitalise } from '../../lib/strings.js';
@@ -20,13 +20,13 @@ const ProducerCredits = props => {
 							: credit.name;
 
 						return (
-							<React.Fragment key={index}>
+							<Fragment key={index}>
 
 								<>{`${creditName} `}</>
 
 								<ProducerEntities entities={credit.entities} />
 
-							</React.Fragment>
+							</Fragment>
 						);
 
 					})

--- a/src/react/components/ProducerEntities.jsx
+++ b/src/react/components/ProducerEntities.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Fragment } from 'react';
 
 import { CommaSeparatedInstanceLinks, InstanceLink } from './index.js';
 
@@ -13,7 +13,7 @@ const ProducerEntities = props => {
 			{
 				entities
 					.map((entity, index) =>
-						<React.Fragment key={index}>
+						<Fragment key={index}>
 
 							{
 								entity.members?.length > 0 && (
@@ -29,7 +29,7 @@ const ProducerEntities = props => {
 
 							<InstanceLink instance={entity} />
 
-						</React.Fragment>
+						</Fragment>
 					)
 					.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
 			}

--- a/src/react/components/ProducerProductionsList.jsx
+++ b/src/react/components/ProducerProductionsList.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { ProducerCredits, ProductionLinkWithContext, ListWrapper } from './index.js';
 

--- a/src/react/components/ProductionLinkWithContext.jsx
+++ b/src/react/components/ProductionLinkWithContext.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { AppendedProductionDates, AppendedVenue, InstanceLink, PrependedSurInstance } from './index.js';
 

--- a/src/react/components/ProductionTeamCreditsList.jsx
+++ b/src/react/components/ProductionTeamCreditsList.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { AppendedEntities, ListWrapper } from './index.js';
 

--- a/src/react/components/ProductionsList.jsx
+++ b/src/react/components/ProductionsList.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { ListWrapper, ProductionLinkWithContext } from './index.js';
 

--- a/src/react/components/SearchBar.jsx
+++ b/src/react/components/SearchBar.jsx
@@ -1,6 +1,6 @@
 /* eslint no-unused-vars: ["error", { "argsIgnorePattern": "(newSelectionPrefix|paginationText|renderMenuItemChildren)" }] */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { AsyncTypeahead, Highlighter } from 'react-bootstrap-typeahead';
 import { useNavigate } from 'react-router-dom';
 

--- a/src/react/components/VenueLinkWithContext.jsx
+++ b/src/react/components/VenueLinkWithContext.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { InstanceLink, PrependedSurInstance } from './index.js';
 

--- a/src/react/components/WritingCredits.jsx
+++ b/src/react/components/WritingCredits.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Fragment } from 'react';
 
 import { WritingEntities } from './index.js';
 import { capitalise } from '../../lib/strings.js';
@@ -20,13 +20,13 @@ const WritingCredits = props => {
 							: credit.name;
 
 						return (
-							<React.Fragment key={index}>
+							<Fragment key={index}>
 
 								<>{`${creditName} `}</>
 
 								<WritingEntities entities={credit.entities} />
 
-							</React.Fragment>
+							</Fragment>
 						);
 
 					})

--- a/src/react/components/WritingEntities.jsx
+++ b/src/react/components/WritingEntities.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Fragment } from 'react';
 
 import { AppendedFormatAndYear, InstanceLink, PrependedSurInstance, WritingCredits } from './index.js';
 
@@ -13,7 +13,7 @@ const WritingEntities = props => {
 			{
 				entities
 					.map((entity, index) =>
-						<React.Fragment key={index}>
+						<Fragment key={index}>
 
 							{
 								entity.surMaterial?.surMaterial && (
@@ -47,7 +47,7 @@ const WritingEntities = props => {
 								)
 							}
 
-						</React.Fragment>
+						</Fragment>
 					)
 					.reduce((accumulator, currentValue, currentIndex) => {
 

--- a/src/react/page-wrappers/InstancePageWrapper.jsx
+++ b/src/react/page-wrappers/InstancePageWrapper.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import getDifferentiatorSuffix from '../../lib/get-differentiator-suffix.js';
 import getInstanceTitle from '../../lib/get-instance-title.js';

--- a/src/react/page-wrappers/ListPageWrapper.jsx
+++ b/src/react/page-wrappers/ListPageWrapper.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { PageTitle } from '../components/index.js';
 

--- a/src/react/pages/Home.jsx
+++ b/src/react/pages/Home.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { PageTitle } from '../components/index.js';
 
 const Home = () => {

--- a/src/react/pages/NotFound.jsx
+++ b/src/react/pages/NotFound.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ErrorMessage } from '../components/index.js';
 
 const NotFound = () => {

--- a/src/react/pages/instances/Award.jsx
+++ b/src/react/pages/instances/Award.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { InstanceFacet, InstanceLinksList } from '../../components/index.js';

--- a/src/react/pages/instances/AwardCeremony.jsx
+++ b/src/react/pages/instances/AwardCeremony.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Fragment } from 'react';
 import { connect } from 'react-redux';
 
 import {
@@ -37,7 +37,7 @@ const AwardCeremony = props => {
 
 						{
 							categories.map((category, index) =>
-								<React.Fragment key={index}>
+								<Fragment key={index}>
 									{ category.name }
 
 									<ListWrapper>
@@ -92,7 +92,7 @@ const AwardCeremony = props => {
 										}
 
 									</ListWrapper>
-								</React.Fragment>
+								</Fragment>
 							)
 						}
 

--- a/src/react/pages/instances/Character.jsx
+++ b/src/react/pages/instances/Character.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import {

--- a/src/react/pages/instances/Company.jsx
+++ b/src/react/pages/instances/Company.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Fragment } from 'react';
 import { connect } from 'react-redux';
 
 import {
@@ -203,7 +203,7 @@ const Company = props => {
 
 						{
 							awards.map((award, index) =>
-								<React.Fragment key={index}>
+								<Fragment key={index}>
 									<InstanceLink instance={award} />
 
 									<ListWrapper>
@@ -216,13 +216,13 @@ const Company = props => {
 													{
 														ceremony.categories
 															.map((category, index) =>
-																<React.Fragment key={index}>
+																<Fragment key={index}>
 																	{ category.name }{': '}
 
 																	{
 																		category.nominations
 																			.map((nomination, index) =>
-																				<React.Fragment key={index}>
+																				<Fragment key={index}>
 																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
 																						{nomination.type}
 																					</span>
@@ -271,11 +271,11 @@ const Company = props => {
 																							</>
 																						)
 																					}
-																				</React.Fragment>
+																				</Fragment>
 																			)
 																			.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
 																	}
-																</React.Fragment>
+																</Fragment>
 															)
 															.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
 													}
@@ -284,7 +284,7 @@ const Company = props => {
 										}
 
 									</ListWrapper>
-								</React.Fragment>
+								</Fragment>
 							)
 						}
 
@@ -298,7 +298,7 @@ const Company = props => {
 
 						{
 							subsequentVersionMaterialAwards.map((subsequentVersionMaterialAward, index) =>
-								<React.Fragment key={index}>
+								<Fragment key={index}>
 									<InstanceLink instance={subsequentVersionMaterialAward} />
 
 									<ListWrapper>
@@ -311,13 +311,13 @@ const Company = props => {
 													{
 														ceremony.categories
 															.map((category, index) =>
-																<React.Fragment key={index}>
+																<Fragment key={index}>
 																	{ category.name }{': '}
 
 																	{
 																		category.nominations
 																			.map((nomination, index) =>
-																				<React.Fragment key={index}>
+																				<Fragment key={index}>
 																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
 																						{nomination.type}
 																					</span>
@@ -369,11 +369,11 @@ const Company = props => {
 																							</>
 																						)
 																					}
-																				</React.Fragment>
+																				</Fragment>
 																			)
 																			.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
 																	}
-																</React.Fragment>
+																</Fragment>
 															)
 															.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
 													}
@@ -382,7 +382,7 @@ const Company = props => {
 										}
 
 									</ListWrapper>
-								</React.Fragment>
+								</Fragment>
 							)
 						}
 
@@ -396,7 +396,7 @@ const Company = props => {
 
 						{
 							sourcingMaterialAwards.map((sourcingMaterialAward, index) =>
-								<React.Fragment key={index}>
+								<Fragment key={index}>
 									<InstanceLink instance={sourcingMaterialAward} />
 
 									<ListWrapper>
@@ -409,13 +409,13 @@ const Company = props => {
 													{
 														ceremony.categories
 															.map((category, index) =>
-																<React.Fragment key={index}>
+																<Fragment key={index}>
 																	{ category.name }{': '}
 
 																	{
 																		category.nominations
 																			.map((nomination, index) =>
-																				<React.Fragment key={index}>
+																				<Fragment key={index}>
 																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
 																						{nomination.type}
 																					</span>
@@ -467,11 +467,11 @@ const Company = props => {
 																							</>
 																						)
 																					}
-																				</React.Fragment>
+																				</Fragment>
 																			)
 																			.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
 																	}
-																</React.Fragment>
+																</Fragment>
 															)
 															.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
 													}
@@ -480,7 +480,7 @@ const Company = props => {
 										}
 
 									</ListWrapper>
-								</React.Fragment>
+								</Fragment>
 							)
 						}
 
@@ -494,7 +494,7 @@ const Company = props => {
 
 						{
 							rightsGrantorMaterialAwards.map((rightsGrantorMaterialAward, index) =>
-								<React.Fragment key={index}>
+								<Fragment key={index}>
 									<InstanceLink instance={rightsGrantorMaterialAward} />
 
 									<ListWrapper>
@@ -507,13 +507,13 @@ const Company = props => {
 													{
 														ceremony.categories
 															.map((category, index) =>
-																<React.Fragment key={index}>
+																<Fragment key={index}>
 																	{ category.name }{': '}
 
 																	{
 																		category.nominations
 																			.map((nomination, index) =>
-																				<React.Fragment key={index}>
+																				<Fragment key={index}>
 																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
 																						{nomination.type}
 																					</span>
@@ -565,11 +565,11 @@ const Company = props => {
 																							</>
 																						)
 																					}
-																				</React.Fragment>
+																				</Fragment>
 																			)
 																			.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
 																	}
-																</React.Fragment>
+																</Fragment>
 															)
 															.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
 													}
@@ -578,7 +578,7 @@ const Company = props => {
 										}
 
 									</ListWrapper>
-								</React.Fragment>
+								</Fragment>
 							)
 						}
 

--- a/src/react/pages/instances/Festival.jsx
+++ b/src/react/pages/instances/Festival.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { InstanceFacet, InstanceLink, ProductionsList } from '../../components/index.js';

--- a/src/react/pages/instances/FestivalSeries.jsx
+++ b/src/react/pages/instances/FestivalSeries.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { InstanceFacet, InstanceLinksList } from '../../components/index.js';

--- a/src/react/pages/instances/Material.jsx
+++ b/src/react/pages/instances/Material.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Fragment } from 'react';
 import { connect } from 'react-redux';
 
 import { capitalise } from '../../../lib/strings.js';
@@ -256,7 +256,7 @@ const Material = props => {
 
 							{
 								awards.map((award, index) =>
-									<React.Fragment key={index}>
+									<Fragment key={index}>
 										<InstanceLink instance={award} />
 
 										<ListWrapper>
@@ -269,13 +269,13 @@ const Material = props => {
 														{
 															ceremony.categories
 																.map((category, index) =>
-																	<React.Fragment key={index}>
+																	<Fragment key={index}>
 																		{ category.name }{': '}
 
 																		{
 																			category.nominations
 																				.map((nomination, index) =>
-																					<React.Fragment key={index}>
+																					<Fragment key={index}>
 																						<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
 																							{nomination.type}
 																						</span>
@@ -339,11 +339,11 @@ const Material = props => {
 																								</>
 																							)
 																						}
-																					</React.Fragment>
+																					</Fragment>
 																				)
 																				.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
 																		}
-																	</React.Fragment>
+																	</Fragment>
 																)
 																.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
 														}
@@ -352,7 +352,7 @@ const Material = props => {
 											}
 
 										</ListWrapper>
-									</React.Fragment>
+									</Fragment>
 								)
 							}
 
@@ -366,7 +366,7 @@ const Material = props => {
 
 							{
 								subsequentVersionMaterialAwards.map((subsequentVersionMaterialAward, index) =>
-									<React.Fragment key={index}>
+									<Fragment key={index}>
 										<InstanceLink instance={subsequentVersionMaterialAward} />
 
 										<ListWrapper>
@@ -379,13 +379,13 @@ const Material = props => {
 														{
 															ceremony.categories
 																.map((category, index) =>
-																	<React.Fragment key={index}>
+																	<Fragment key={index}>
 																		{ category.name }{': '}
 
 																		{
 																			category.nominations
 																				.map((nomination, index) =>
-																					<React.Fragment key={index}>
+																					<Fragment key={index}>
 																						<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
 																							{nomination.type}
 																						</span>
@@ -441,11 +441,11 @@ const Material = props => {
 																								</>
 																							)
 																						}
-																					</React.Fragment>
+																					</Fragment>
 																				)
 																				.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
 																		}
-																	</React.Fragment>
+																	</Fragment>
 																)
 																.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
 														}
@@ -454,7 +454,7 @@ const Material = props => {
 											}
 
 										</ListWrapper>
-									</React.Fragment>
+									</Fragment>
 								)
 							}
 
@@ -468,7 +468,7 @@ const Material = props => {
 
 							{
 								sourcingMaterialAwards.map((sourcingMaterialAward, index) =>
-									<React.Fragment key={index}>
+									<Fragment key={index}>
 										<InstanceLink instance={sourcingMaterialAward} />
 
 										<ListWrapper>
@@ -481,13 +481,13 @@ const Material = props => {
 														{
 															ceremony.categories
 																.map((category, index) =>
-																	<React.Fragment key={index}>
+																	<Fragment key={index}>
 																		{ category.name }{': '}
 
 																		{
 																			category.nominations
 																				.map((nomination, index) =>
-																					<React.Fragment key={index}>
+																					<Fragment key={index}>
 																						<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
 																							{nomination.type}
 																						</span>
@@ -543,11 +543,11 @@ const Material = props => {
 																								</>
 																							)
 																						}
-																					</React.Fragment>
+																					</Fragment>
 																				)
 																				.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
 																		}
-																	</React.Fragment>
+																	</Fragment>
 																)
 																.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
 														}
@@ -556,7 +556,7 @@ const Material = props => {
 											}
 
 										</ListWrapper>
-									</React.Fragment>
+									</Fragment>
 								)
 							}
 

--- a/src/react/pages/instances/Person.jsx
+++ b/src/react/pages/instances/Person.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Fragment } from 'react';
 import { connect } from 'react-redux';
 
 import {
@@ -233,7 +233,7 @@ const Person = props => {
 
 						{
 							awards.map((award, index) =>
-								<React.Fragment key={index}>
+								<Fragment key={index}>
 									<InstanceLink instance={award} />
 
 									<ListWrapper>
@@ -246,13 +246,13 @@ const Person = props => {
 													{
 														ceremony.categories
 															.map((category, index) =>
-																<React.Fragment key={index}>
+																<Fragment key={index}>
 																	{ category.name }{': '}
 
 																	{
 																		category.nominations
 																			.map((nomination, index) =>
-																				<React.Fragment key={index}>
+																				<Fragment key={index}>
 																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
 																						{nomination.type}
 																					</span>
@@ -301,11 +301,11 @@ const Person = props => {
 																							</>
 																						)
 																					}
-																				</React.Fragment>
+																				</Fragment>
 																			)
 																			.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
 																	}
-																</React.Fragment>
+																</Fragment>
 															)
 															.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
 													}
@@ -314,7 +314,7 @@ const Person = props => {
 										}
 
 									</ListWrapper>
-								</React.Fragment>
+								</Fragment>
 							)
 						}
 
@@ -328,7 +328,7 @@ const Person = props => {
 
 						{
 							subsequentVersionMaterialAwards.map((subsequentVersionMaterialAward, index) =>
-								<React.Fragment key={index}>
+								<Fragment key={index}>
 									<InstanceLink instance={subsequentVersionMaterialAward} />
 
 									<ListWrapper>
@@ -341,13 +341,13 @@ const Person = props => {
 													{
 														ceremony.categories
 															.map((category, index) =>
-																<React.Fragment key={index}>
+																<Fragment key={index}>
 																	{ category.name }{': '}
 
 																	{
 																		category.nominations
 																			.map((nomination, index) =>
-																				<React.Fragment key={index}>
+																				<Fragment key={index}>
 																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
 																						{nomination.type}
 																					</span>
@@ -399,11 +399,11 @@ const Person = props => {
 																							</>
 																						)
 																					}
-																				</React.Fragment>
+																				</Fragment>
 																			)
 																			.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
 																	}
-																</React.Fragment>
+																</Fragment>
 															)
 															.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
 													}
@@ -412,7 +412,7 @@ const Person = props => {
 										}
 
 									</ListWrapper>
-								</React.Fragment>
+								</Fragment>
 							)
 						}
 
@@ -426,7 +426,7 @@ const Person = props => {
 
 						{
 							sourcingMaterialAwards.map((sourcingMaterialAward, index) =>
-								<React.Fragment key={index}>
+								<Fragment key={index}>
 									<InstanceLink instance={sourcingMaterialAward} />
 
 									<ListWrapper>
@@ -439,13 +439,13 @@ const Person = props => {
 													{
 														ceremony.categories
 															.map((category, index) =>
-																<React.Fragment key={index}>
+																<Fragment key={index}>
 																	{ category.name }{': '}
 
 																	{
 																		category.nominations
 																			.map((nomination, index) =>
-																				<React.Fragment key={index}>
+																				<Fragment key={index}>
 																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
 																						{nomination.type}
 																					</span>
@@ -497,11 +497,11 @@ const Person = props => {
 																							</>
 																						)
 																					}
-																				</React.Fragment>
+																				</Fragment>
 																			)
 																			.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
 																	}
-																</React.Fragment>
+																</Fragment>
 															)
 															.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
 													}
@@ -510,7 +510,7 @@ const Person = props => {
 										}
 
 									</ListWrapper>
-								</React.Fragment>
+								</Fragment>
 							)
 						}
 
@@ -524,7 +524,7 @@ const Person = props => {
 
 						{
 							rightsGrantorMaterialAwards.map((rightsGrantorMaterialAward, index) =>
-								<React.Fragment key={index}>
+								<Fragment key={index}>
 									<InstanceLink instance={rightsGrantorMaterialAward} />
 
 									<ListWrapper>
@@ -537,13 +537,13 @@ const Person = props => {
 													{
 														ceremony.categories
 															.map((category, index) =>
-																<React.Fragment key={index}>
+																<Fragment key={index}>
 																	{ category.name }{': '}
 
 																	{
 																		category.nominations
 																			.map((nomination, index) =>
-																				<React.Fragment key={index}>
+																				<Fragment key={index}>
 																					<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
 																						{nomination.type}
 																					</span>
@@ -595,11 +595,11 @@ const Person = props => {
 																							</>
 																						)
 																					}
-																				</React.Fragment>
+																				</Fragment>
 																			)
 																			.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
 																	}
-																</React.Fragment>
+																</Fragment>
 															)
 															.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
 													}
@@ -608,7 +608,7 @@ const Person = props => {
 										}
 
 									</ListWrapper>
-								</React.Fragment>
+								</Fragment>
 							)
 						}
 

--- a/src/react/pages/instances/Production.jsx
+++ b/src/react/pages/instances/Production.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Fragment } from 'react';
 import { connect } from 'react-redux';
 
 import { formatDate } from '../../../lib/format-date.js';
@@ -286,7 +286,7 @@ const Production = props => {
 
 							{
 								awards.map((award, index) =>
-									<React.Fragment key={index}>
+									<Fragment key={index}>
 										<InstanceLink instance={award} />
 
 										<ListWrapper>
@@ -299,13 +299,13 @@ const Production = props => {
 														{
 															ceremony.categories
 																.map((category, index) =>
-																	<React.Fragment key={index}>
+																	<Fragment key={index}>
 																		{ category.name }{': '}
 
 																		{
 																			category.nominations
 																				.map((nomination, index) =>
-																					<React.Fragment key={index}>
+																					<Fragment key={index}>
 																						<span className={nomination.isWinner ? 'nomination-winner-text' : ''}>
 																							{nomination.type}
 																						</span>
@@ -376,11 +376,11 @@ const Production = props => {
 																								</>
 																							)
 																						}
-																					</React.Fragment>
+																					</Fragment>
 																				)
 																				.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])
 																		}
-																	</React.Fragment>
+																	</Fragment>
 																)
 																.reduce((accumulator, currentValue) => [accumulator, '; ', currentValue])
 														}
@@ -389,7 +389,7 @@ const Production = props => {
 											}
 
 										</ListWrapper>
-									</React.Fragment>
+									</Fragment>
 								)
 							}
 

--- a/src/react/pages/instances/Season.jsx
+++ b/src/react/pages/instances/Season.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { InstanceFacet, ProductionsList } from '../../components/index.js';

--- a/src/react/pages/instances/Venue.jsx
+++ b/src/react/pages/instances/Venue.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { InstanceFacet, InstanceLink, InstanceLinksList, ProductionsList } from '../../components/index.js';

--- a/src/react/pages/lists/AwardCeremonies.jsx
+++ b/src/react/pages/lists/AwardCeremonies.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { InstanceLink, ListWrapper } from '../../components/index.js';

--- a/src/react/pages/lists/Awards.jsx
+++ b/src/react/pages/lists/Awards.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { InstanceLinksList } from '../../components/index.js';

--- a/src/react/pages/lists/Characters.jsx
+++ b/src/react/pages/lists/Characters.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { InstanceLinksList } from '../../components/index.js';

--- a/src/react/pages/lists/Companies.jsx
+++ b/src/react/pages/lists/Companies.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { InstanceLinksList } from '../../components/index.js';

--- a/src/react/pages/lists/FestivalSerieses.jsx
+++ b/src/react/pages/lists/FestivalSerieses.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { InstanceLinksList } from '../../components/index.js';

--- a/src/react/pages/lists/Festivals.jsx
+++ b/src/react/pages/lists/Festivals.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { InstanceLink, ListWrapper } from '../../components/index.js';

--- a/src/react/pages/lists/Materials.jsx
+++ b/src/react/pages/lists/Materials.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { MaterialsList } from '../../components/index.js';

--- a/src/react/pages/lists/People.jsx
+++ b/src/react/pages/lists/People.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { InstanceLinksList } from '../../components/index.js';

--- a/src/react/pages/lists/Productions.jsx
+++ b/src/react/pages/lists/Productions.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { ProductionsList } from '../../components/index.js';

--- a/src/react/pages/lists/Seasons.jsx
+++ b/src/react/pages/lists/Seasons.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { InstanceLinksList } from '../../components/index.js';

--- a/src/react/pages/lists/Venues.jsx
+++ b/src/react/pages/lists/Venues.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { InstanceLink, ListWrapper } from '../../components/index.js';

--- a/src/react/react-html.jsx
+++ b/src/react/react-html.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { Provider } from 'react-redux';
 import { StaticRouter } from 'react-router-dom/server.js';


### PR DESCRIPTION
When switching to Rollup.js in PR https://github.com/andygout/dramatis-spa/pull/221, this [DEV Community article](https://dev.to/vvkkumar06/setup-rollup-for-react-library-project-2024-3jea) mentioned that it is possible to:
> [eliminate] the need for a global React import in each file that uses JSX

This is achieved in the rollup.config.js file by modifying the value of the `presets` property in the object passed as an argument to the function provided by `@rollup/plugin-babel` (and some equivalent changes for the server bundle).

### References:
- [DEV Community: Setup rollup for React Library project - 2024](https://dev.to/vvkkumar06/setup-rollup-for-react-library-project-2024-3jea) by Vivek Kumar
  - > **What is runtime: "automatic ?**
     > The "automatic" runtime in Babel refers to the new JSX transform introduced in Babel 17. This transform changes how JSX is compiled, and it eliminates the need for a global React import in each file that uses JSX.
     > With the introduction of the automatic runtime in Babel 17, the need for the explicit React import is eliminated.
- [React Blog: Introducing the New JSX Transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)
- [npm: rollup-plugin-esbuild](https://www.npmjs.com/package/rollup-plugin-esbuild#usage)
  - Demonstrates the `jsx` property
- [GitHub: evanw / esbuild — Issue: Support jsx automatic runtime — comment from evanw](https://github.com/evanw/esbuild/issues/334)
- [esbuild: Content Types — Auto-import for JSX](https://esbuild.github.io/content-types/#auto-import-for-jsx)
  - Demonstrates that `'automatic'` is a valid argument for the `jsx` property