### PR TITLE
Remove esbuild object argument properties (jsxFactory + jsxFragment)

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,9 +35,7 @@ const serverBundle = {
 	},
 	plugins: [
 		esbuild({
-			jsx: 'automatic',
-			jsxFactory: 'React.createElement',
-			jsxFragment: 'React.Fragment'
+			jsx: 'automatic'
 		}),
 		copy({
 			targets: [


### PR DESCRIPTION
This repo currently explicitly expresses its JSX factory and JSX fragment settings (using the default values) for the sake of consistency with [dramatis-ssr](https://github.com/andygout/dramatis-ssr) which uses Preact and so needs to declare its (non-default) values.

[dramatis-ssr](https://github.com/andygout/dramatis-ssr) recently made changes which prevents it from needing to explicitly express those settings (see PR: https://github.com/andygout/dramatis-ssr/pull/259), and so this repo can correspondingly remove those settings too.

### References:
- [GitHub: egoist/rollup-plugin-esbuild — Usage](https://github.com/egoist/rollup-plugin-esbuild#usage)