### PR TITLE
Resolve Rollup 'Circular dependencies' warning

### DIFF
--- a/src/react/components/AppendedCoEntities.jsx
+++ b/src/react/components/AppendedCoEntities.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { Entities } from './index.js';
+import Entities from './Entities.jsx';
 
 const AppendedCoEntities = props => {
 

--- a/src/react/components/AppendedEmployerCompany.jsx
+++ b/src/react/components/AppendedEmployerCompany.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 
-import { CommaSeparatedInstanceLinks, InstanceLink } from './index.js';
+import CommaSeparatedInstanceLinks from './CommaSeparatedInstanceLinks.jsx';
+import InstanceLink from './InstanceLink.jsx';
 
 const AppendedEmployerCompany = props => {
 

--- a/src/react/components/AppendedEntities.jsx
+++ b/src/react/components/AppendedEntities.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { Entities } from './index.js';
+import Entities from './Entities.jsx';
 
 const AppendedEntities = props => {
 

--- a/src/react/components/AppendedMembers.jsx
+++ b/src/react/components/AppendedMembers.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { CommaSeparatedInstanceLinks } from './index.js';
+import CommaSeparatedInstanceLinks from './CommaSeparatedInstanceLinks.jsx';
 
 const AppendedMembers = props => {
 

--- a/src/react/components/AppendedPerformers.jsx
+++ b/src/react/components/AppendedPerformers.jsx
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import { Fragment } from 'react';
 
-import { InstanceLink, JoinedRoles } from './index.js';
+import InstanceLink from './InstanceLink.jsx';
+import JoinedRoles from './JoinedRoles.jsx';
 
 const AppendedPerformers = props => {
 

--- a/src/react/components/AppendedProductionTeamCredits.jsx
+++ b/src/react/components/AppendedProductionTeamCredits.jsx
@@ -1,7 +1,9 @@
 import PropTypes from 'prop-types';
 import { Fragment } from 'react';
 
-import { AppendedCoEntities, AppendedEmployerCompany, AppendedMembers } from './index.js';
+import AppendedCoEntities from './AppendedCoEntities.jsx';
+import AppendedEmployerCompany from './AppendedEmployerCompany.jsx';
+import AppendedMembers from './AppendedMembers.jsx';
 
 const AppendedProductionTeamCredits = props => {
 

--- a/src/react/components/AppendedRoles.jsx
+++ b/src/react/components/AppendedRoles.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { JoinedRoles } from './index.js';
+import JoinedRoles from './JoinedRoles.jsx';
 
 const AppendedRoles = props => {
 

--- a/src/react/components/AppendedVenue.jsx
+++ b/src/react/components/AppendedVenue.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { VenueLinkWithContext } from './index.js';
+import VenueLinkWithContext from './VenueLinkWithContext.jsx';
 
 const AppendedVenue = props => {
 

--- a/src/react/components/CharactersList.jsx
+++ b/src/react/components/CharactersList.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 
-import { AppendedQualifier, InstanceLink, ListWrapper } from './index.js';
+import AppendedQualifier from './AppendedQualifier.jsx';
+import InstanceLink from './InstanceLink.jsx';
+import ListWrapper from './ListWrapper.jsx';
 
 const CharactersList = props => {
 

--- a/src/react/components/CommaSeparatedInstanceLinks.jsx
+++ b/src/react/components/CommaSeparatedInstanceLinks.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { Fragment } from 'react';
 
-import { InstanceLink } from './index.js';
+import InstanceLink from './InstanceLink.jsx';
 
 const CommaSeparatedInstanceLinks = props => {
 

--- a/src/react/components/CommaSeparatedMaterials.jsx
+++ b/src/react/components/CommaSeparatedMaterials.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { Fragment } from 'react';
 
-import { MaterialLinkWithContext } from './index.js';
+import MaterialLinkWithContext from './MaterialLinkWithContext.jsx';
 
 const CommaSeparatedMaterials = props => {
 

--- a/src/react/components/CommaSeparatedProductions.jsx
+++ b/src/react/components/CommaSeparatedProductions.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { Fragment } from 'react';
 
-import { ProductionLinkWithContext } from './index.js';
+import ProductionLinkWithContext from './ProductionLinkWithContext.jsx';
 
 const CommaSeparatedProductions = props => {
 

--- a/src/react/components/CreativeProductionsList.jsx
+++ b/src/react/components/CreativeProductionsList.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 
-import { AppendedProductionTeamCredits, ProductionLinkWithContext, ListWrapper } from './index.js';
+import AppendedProductionTeamCredits from './AppendedProductionTeamCredits.jsx';
+import ProductionLinkWithContext from './ProductionLinkWithContext.jsx';
+import ListWrapper from './ListWrapper.jsx';
 
 const CreativeProductionsList = props => {
 

--- a/src/react/components/CrewProductionsList.jsx
+++ b/src/react/components/CrewProductionsList.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 
-import { AppendedProductionTeamCredits, ProductionLinkWithContext, ListWrapper } from './index.js';
+import AppendedProductionTeamCredits from './AppendedProductionTeamCredits.jsx';
+import ProductionLinkWithContext from './ProductionLinkWithContext.jsx';
+import ListWrapper from './ListWrapper.jsx';
 
 const CrewProductionsList = props => {
 

--- a/src/react/components/Entities.jsx
+++ b/src/react/components/Entities.jsx
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import { Fragment } from 'react';
 
-import { AppendedMembers, InstanceLink } from './index.js';
+import AppendedMembers from './AppendedMembers.jsx';
+import InstanceLink from './InstanceLink.jsx';
 
 const Entities = props => {
 

--- a/src/react/components/ErrorMessage.jsx
+++ b/src/react/components/ErrorMessage.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 
-import { PageTitle } from './index.js';
+import PageTitle from './PageTitle.jsx';
 
 const ErrorMessage = props => {
 

--- a/src/react/components/FestivalLinkWithContext.jsx
+++ b/src/react/components/FestivalLinkWithContext.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 
-import { InstanceLink, PrependedSurInstance } from './index.js';
+import InstanceLink from './InstanceLink.jsx';
+import PrependedSurInstance from './PrependedSurInstance.jsx';
 
 const FestivalLinkWithContext = props => {
 

--- a/src/react/components/Header.jsx
+++ b/src/react/components/Header.jsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 
-import { SearchBar } from './index.js';
+import SearchBar from './SearchBar.jsx';
 
 const Header = () => {
 

--- a/src/react/components/InstanceLinksList.jsx
+++ b/src/react/components/InstanceLinksList.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 
-import { InstanceLink, ListWrapper } from './index.js';
+import InstanceLink from './InstanceLink.jsx';
+import ListWrapper from './ListWrapper.jsx';
 
 const InstanceLinksList = props => {
 

--- a/src/react/components/JoinedRoles.jsx
+++ b/src/react/components/JoinedRoles.jsx
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import { Fragment } from 'react';
 
-import { AppendedQualifier, InstanceLink } from './index.js';
+import AppendedQualifier from './AppendedQualifier.jsx';
+import InstanceLink from './InstanceLink.jsx';
 
 const JoinedRoles = props => {
 

--- a/src/react/components/MaterialLinkWithContext.jsx
+++ b/src/react/components/MaterialLinkWithContext.jsx
@@ -1,6 +1,9 @@
 import PropTypes from 'prop-types';
 
-import { AppendedFormatAndYear, InstanceLink, PrependedSurInstance, WritingCredits } from './index.js';
+import AppendedFormatAndYear from './AppendedFormatAndYear.jsx';
+import InstanceLink from './InstanceLink.jsx';
+import PrependedSurInstance from './PrependedSurInstance.jsx';
+import WritingCredits from './WritingCredits.jsx';
 
 const MaterialLinkWithContext = props => {
 

--- a/src/react/components/MaterialsList.jsx
+++ b/src/react/components/MaterialsList.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 
-import { ListWrapper, MaterialLinkWithContext } from './index.js';
+import ListWrapper from './ListWrapper.jsx';
+import MaterialLinkWithContext from './MaterialLinkWithContext.jsx';
 
 const MaterialsList = props => {
 

--- a/src/react/components/PrependedSurInstance.jsx
+++ b/src/react/components/PrependedSurInstance.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { InstanceLink } from './index.js';
+import InstanceLink from './InstanceLink.jsx';
 
 const PrependedSurInstance = props => {
 

--- a/src/react/components/ProducerCredits.jsx
+++ b/src/react/components/ProducerCredits.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import { Fragment } from 'react';
 
-import { ProducerEntities } from './index.js';
 import { capitalise } from '../../lib/strings.js';
+import ProducerEntities from './ProducerEntities.jsx';
 
 const ProducerCredits = props => {
 

--- a/src/react/components/ProducerEntities.jsx
+++ b/src/react/components/ProducerEntities.jsx
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import { Fragment } from 'react';
 
-import { CommaSeparatedInstanceLinks, InstanceLink } from './index.js';
+import CommaSeparatedInstanceLinks from './CommaSeparatedInstanceLinks.jsx';
+import InstanceLink from './InstanceLink.jsx';
 
 const ProducerEntities = props => {
 

--- a/src/react/components/ProducerProductionsList.jsx
+++ b/src/react/components/ProducerProductionsList.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 
-import { ProducerCredits, ProductionLinkWithContext, ListWrapper } from './index.js';
+import ProducerCredits from './ProducerCredits.jsx';
+import ProductionLinkWithContext from './ProductionLinkWithContext.jsx';
+import ListWrapper from './ListWrapper.jsx';
 
 const ProducerProductionsList = props => {
 

--- a/src/react/components/ProductionLinkWithContext.jsx
+++ b/src/react/components/ProductionLinkWithContext.jsx
@@ -1,6 +1,9 @@
 import PropTypes from 'prop-types';
 
-import { AppendedProductionDates, AppendedVenue, InstanceLink, PrependedSurInstance } from './index.js';
+import AppendedProductionDates from './AppendedProductionDates.jsx';
+import AppendedVenue from './AppendedVenue.jsx';
+import InstanceLink from './InstanceLink.jsx';
+import PrependedSurInstance from './PrependedSurInstance.jsx';
 
 const ProductionLinkWithContext = props => {
 

--- a/src/react/components/ProductionTeamCreditsList.jsx
+++ b/src/react/components/ProductionTeamCreditsList.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 
-import { AppendedEntities, ListWrapper } from './index.js';
+import AppendedEntities from './AppendedEntities.jsx';
+import ListWrapper from './ListWrapper.jsx';
 
 const ProductionTeamCreditsList = props => {
 

--- a/src/react/components/ProductionsList.jsx
+++ b/src/react/components/ProductionsList.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 
-import { ListWrapper, ProductionLinkWithContext } from './index.js';
+import ListWrapper from './ListWrapper.jsx';
+import ProductionLinkWithContext from './ProductionLinkWithContext.jsx';
 
 const ProductionsList = props => {
 

--- a/src/react/components/VenueLinkWithContext.jsx
+++ b/src/react/components/VenueLinkWithContext.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 
-import { InstanceLink, PrependedSurInstance } from './index.js';
+import InstanceLink from './InstanceLink.jsx';
+import PrependedSurInstance from './PrependedSurInstance.jsx';
 
 const VenueLinkWithContext = props => {
 

--- a/src/react/components/WritingCredits.jsx
+++ b/src/react/components/WritingCredits.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import { Fragment } from 'react';
 
-import { WritingEntities } from './index.js';
 import { capitalise } from '../../lib/strings.js';
+import WritingEntities from './WritingEntities.jsx';
 
 const WritingCredits = props => {
 

--- a/src/react/components/WritingEntities.jsx
+++ b/src/react/components/WritingEntities.jsx
@@ -1,7 +1,10 @@
 import PropTypes from 'prop-types';
 import { Fragment } from 'react';
 
-import { AppendedFormatAndYear, InstanceLink, PrependedSurInstance, WritingCredits } from './index.js';
+import AppendedFormatAndYear from './AppendedFormatAndYear.jsx';
+import InstanceLink from './InstanceLink.jsx';
+import PrependedSurInstance from './PrependedSurInstance.jsx';
+import WritingCredits from './WritingCredits.jsx';
 
 const WritingEntities = props => {
 


### PR DESCRIPTION
The `npm run build` command (which triggers the Rollup build task) currently outputs the below warning:

> src/server/app.js → built/main.js...
> (!) Circular dependencies
> src/react/components/index.js -> src/react/components/AppendedCoEntities.jsx -> src/react/components/index.js
> src/react/components/index.js -> src/react/components/AppendedEmployerCompany.jsx -> > src/react/components/index.js
> src/react/components/index.js -> src/react/components/AppendedEntities.jsx -> src/react/components/index.js
> ...and 29 more
> created built/main.js in 571ms

This PR resolves the majority of those circular dependencies.

One circular dependency remains:
> src/server/app.js → built/main.js...
> (!) Circular dependency
> src/react/components/WritingCredits.jsx -> src/react/components/WritingEntities.jsx -> src/react/components/WritingCredits.jsx
> created built/main.js in 543ms

This is required for instances such as those in the below link that include `writingCredits.entities.writingCredits.entities`:

https://github.com/andygout/dramatis-api/blob/68e1d419a923d10d4f49a320bfe7722d5013a14c/test-e2e/model-interaction/mats-with-source-mat.test.js#L399-L514