### PR TITLE
Redux Toolkit: Store setup with configureStore

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "npm": "10.7.0"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "2.5.0",
     "bootstrap": "5.3.3",
     "express": "4.21.2",
     "express-session": "1.18.1",
@@ -40,9 +41,7 @@
     "react-helmet": "6.1.0",
     "react-redux": "9.2.0",
     "react-router-dom": "6.23.1",
-    "redux": "5.0.1",
     "redux-logger": "3.0.6",
-    "redux-thunk": "3.1.0",
     "serve-favicon": "2.5.0"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,6 +15,7 @@ const serverBundle = {
 		sourcemap: 'inline'
 	},
 	external: [
+		'@reduxjs/toolkit',
 		'express',
 		'express-session',
 		'morgan',
@@ -30,8 +31,6 @@ const serverBundle = {
 		'react-redux',
 		'react-router-dom',
 		'react-router-dom/server.js',
-		'redux',
-		'redux-thunk',
 		'serve-favicon'
 	],
 	watch: {

--- a/src/react/client-mount.jsx
+++ b/src/react/client-mount.jsx
@@ -1,9 +1,8 @@
+import { configureStore } from '@reduxjs/toolkit';
 import { hydrateRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
-import { applyMiddleware, createStore, combineReducers } from 'redux';
-import { createLogger } from 'redux-logger';
-import { thunk as thunkMiddleware } from 'redux-thunk';
+import reduxLoggerMiddleware from 'redux-logger';
 
 import AppRoutes from './AppRoutes.jsx';
 import reducers from '../redux/reducers/index.js';
@@ -12,13 +11,24 @@ window.onload = () => {
 
 	const preloadedState = JSON.parse(document.getElementById('react-client-data').innerText);
 
-	const loggerMiddleware = createLogger();
+	const middleware = getDefaultMiddleware => {
 
-	const store = createStore(
-		combineReducers(reducers),
+		const middleware = getDefaultMiddleware();
+
+		if (process.env.NODE_ENV !== 'production') {
+			middleware.push(reduxLoggerMiddleware);
+		}
+
+		return middleware;
+
+	};
+
+	const store = configureStore({
+		reducer: reducers,
 		preloadedState,
-		applyMiddleware(...[thunkMiddleware, loggerMiddleware])
-	);
+		middleware,
+		devTools: process.env.NODE_ENV !== 'production'
+	});
 
 	hydrateRoot(
 		document.getElementById('page-container'),

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -1,8 +1,7 @@
+import { configureStore } from '@reduxjs/toolkit';
 import { Router } from 'express';
 import { Helmet } from 'react-helmet';
 import { matchPath } from 'react-router-dom';
-import { applyMiddleware, createStore, combineReducers } from 'redux';
-import { thunk as thunkMiddleware } from 'redux-thunk';
 
 import getReactHtml from '../react/react-html.jsx';
 import reducers from '../redux/reducers/index.js';
@@ -10,11 +9,10 @@ import routes from '../react/routes.js';
 
 const router = new Router();
 
-const store = createStore(
-	combineReducers(reducers),
-	{},
-	applyMiddleware(...[thunkMiddleware])
-);
+const store = configureStore({
+	reducer: reducers,
+	middleware: getDefaultMiddleware => getDefaultMiddleware()
+});
 
 router.get('*', async (request, response, next) => {
 


### PR DESCRIPTION
This PR implements the steps described in the [Store Setup with `configureStore`](https://redux.js.org/usage/migrating-to-modern-redux#store-setup-with-configurestore) section of the [Migrating to Modern Redux](https://redux.js.org/usage/migrating-to-modern-redux) guide.

### References:
- [Migrating to Modern Redux: Store Setup with `configureStore`](https://redux.js.org/usage/migrating-to-modern-redux#store-setup-with-configurestore)

### New dependencies:
- [@reduxjs/toolkit](https://www.npmjs.com/package/@reduxjs/toolkit)