### PR TITLE
Upgrade react-bootstrap-typeahead 6.3.4 -> 6.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "morgan": "1.10.0",
     "prop-types": "15.8.1",
     "react": "18.3.1",
-    "react-bootstrap-typeahead": "6.3.4",
+    "react-bootstrap-typeahead": "6.4.0",
     "react-dom": "18.3.1",
     "react-helmet": "6.1.0",
     "react-redux": "9.2.0",


### PR DESCRIPTION
This PR upgrades react-bootstrap-typehead to the latest current version ([v.6.4.0](https://github.com/ericgio/react-bootstrap-typeahead/releases/tag/v6.4.0)) which includes the changes to add support for React v19.