### PR TITLE
Restructure Layout + AppRoutes components

### DIFF
--- a/src/react/AppRoutes.jsx
+++ b/src/react/AppRoutes.jsx
@@ -1,6 +1,6 @@
 import { Route, Routes, useLocation } from 'react-router';
 
-import Layout from './Layout.jsx';
+import Main from './Main.jsx';
 import routes from './routes.js';
 
 const AppRoutes = () => {
@@ -18,13 +18,13 @@ const AppRoutes = () => {
 							key={index}
 							path={route.path}
 							element={
-								<Layout
+								<Main
 									key={location.pathname}
 									pageTitle={route.pageTitle}
 									deactivateError={route.deactivateError}
 								>
 									<RouteComponent />
-								</Layout>
+								</Main>
 							}
 						/>
 					);

--- a/src/react/Layout.jsx
+++ b/src/react/Layout.jsx
@@ -1,45 +1,17 @@
-import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-
-import getDocumentTitle from '../lib/get-document-title.js';
-import { ErrorMessage, Footer, Header, Navigation } from './components/index.js';
+import { Footer, Header, Navigation } from './components/index.js';
 
 const Layout = props => {
 
-	const { pageTitle, children } = props;
-
-	const documentTitle = getDocumentTitle(pageTitle);
-
-	const dispatch = useDispatch();
-
-	const error = useSelector(state => state.error);
-
-	useEffect(() => {
-
-		const { deactivateError } = props;
-
-		if (deactivateError) dispatch(deactivateError());
-
-	}, []);
+	const { children } = props;
 
 	return (
 		<>
-
-			<title>{documentTitle}</title>
 
 			<Header />
 
 			<Navigation />
 
-			<main className="main-content">
-
-				{
-					error.isActive
-						? <ErrorMessage errorText={error.message} />
-						: children
-				}
-
-			</main>
+			{ children }
 
 			<Footer />
 

--- a/src/react/Main.jsx
+++ b/src/react/Main.jsx
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import getDocumentTitle from '../lib/get-document-title.js';
+import { ErrorMessage } from './components/index.js';
+
+const Main = props => {
+
+	const { pageTitle, children } = props;
+
+	const documentTitle = getDocumentTitle(pageTitle);
+
+	const dispatch = useDispatch();
+
+	const error = useSelector(state => state.error);
+
+	useEffect(() => {
+
+		const { deactivateError } = props;
+
+		if (deactivateError) dispatch(deactivateError());
+
+	}, []);
+
+	return (
+		<>
+
+			<title>{documentTitle}</title>
+
+			<main className="main-content">
+
+				{
+					error.isActive
+						? <ErrorMessage errorText={error.message} />
+						: children
+				}
+
+			</main>
+
+		</>
+	);
+
+};
+
+export default Main;

--- a/src/react/client-mount.jsx
+++ b/src/react/client-mount.jsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from 'react-router';
 import reduxLoggerMiddleware from 'redux-logger';
 
 import AppRoutes from './AppRoutes.jsx';
+import Layout from './Layout.jsx';
 import reducers from '../redux/reducers/index.js';
 import { api } from '../redux/slices/api.js';
 
@@ -35,7 +36,9 @@ window.onload = () => {
 		document.getElementById('page-container'),
 		<Provider store={store}>
 			<BrowserRouter>
-				<AppRoutes />
+				<Layout>
+					<AppRoutes />
+				</Layout>
 			</BrowserRouter>
 		</Provider>
 	);

--- a/src/react/components/SearchBar.jsx
+++ b/src/react/components/SearchBar.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { AsyncTypeahead, Highlighter } from 'react-bootstrap-typeahead';
 import { useNavigate } from 'react-router';
 
@@ -19,6 +19,8 @@ async function performFetch (url) {
 }
 
 const SearchBar = () => {
+
+	const typeaheadRef = useRef(null);
 
 	const [isLoading, setIsLoading] = useState(false);
 	const [options, setOptions] = useState([]);
@@ -47,6 +49,13 @@ const SearchBar = () => {
 
 			const instancePath = `/${MODEL_TO_ROUTE_MAP[model]}/${uuid}`;
 
+			if (typeaheadRef.current) {
+
+				typeaheadRef.current.blur();
+				typeaheadRef.current.clear();
+
+			}
+
 			navigate(instancePath);
 
 		}
@@ -55,6 +64,7 @@ const SearchBar = () => {
 
 	return (
 		<AsyncTypeahead
+			ref={typeaheadRef}
 			id='search-result-options'
 			filterBy={() => true}
 			delay={1000}

--- a/src/react/react-html.jsx
+++ b/src/react/react-html.jsx
@@ -3,12 +3,15 @@ import { Provider } from 'react-redux';
 import { StaticRouter } from 'react-router';
 
 import AppRoutes from './AppRoutes.jsx';
+import Layout from './Layout.jsx';
 
 const reactHtml = (request, store) =>
 	renderToString(
 		<Provider store={store}>
 			<StaticRouter location={request.url} context={{}}>
-				<AppRoutes />
+				<Layout>
+					<AppRoutes />
+				</Layout>
 			</StaticRouter>
 		</Provider>
 	);


### PR DESCRIPTION
This PR fixes the following issue that has appeared since merging PR https://github.com/andygout/dramatis-spa/pull/246 ("Upgrade react-bootstrap-typeahead 6.3.4 -> 6.4.0").

#### Steps to reproduce:
- Visit any page
- Find an entry in the header search input
- Click on one of the options, which will redirect the user to the corresponding instance page
- Click anywhere on the page

The following console warning will appear for this and every subsequent click:
> Warning: [react-bootstrap-typeahead] ClickOutside captured a close event but does not have a ref to compare it to. useClickOutside(), should be passed a ref that resolves to a DOM node

The source of this warning can be pinpointed to this commit introduced as part of [react-bootstrap-typeahead](https://github.com/ericgio/react-bootstrap-typeahead) [v6.4.0](https://github.com/ericgio/react-bootstrap-typeahead/releases/tag/v6.4.0): [Add `useRootClose` hook](https://github.com/ericgio/react-bootstrap-typeahead/commit/c8c7267eef8b04a5cad375b6899e2002eed975c8) (in `src/components/RootClose/useClickOutside.ts`, lines 47-51).

The fix involved ensuring that the SearchBar component was mounted at a higher level than the AppRoutes components so that when `navigate()` is invoked (triggered by selecting one of the SearchBar component's options) it remains mounted across page navigations rather than being re-mounted and losing its `ref` value.

### References:
- [ChatGPT: React-Bootstrap-Typeahead Help](https://chatgpt.com/c/67b4cc39-9c78-8012-8f9a-48570ccb5209)